### PR TITLE
Update version 1.1.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mvGPS
 Title: Causal Inference using Multivariate Generalized Propensity Score
-Version: 1.1.0
+Version: 1.1.1
 Authors@R: 
     person(given = "Justin",
            family = "Williams",


### PR DESCRIPTION
This PR closes #1 by allowing the balance function to properly return estimates when assuming common shared covariates. It also implements a tryCatch function when estimating methods from WeightIt, as I noticed that sometimes these would return errors. The user will be warned when fitting fails and can try either estimating it separately or re-specifying the covariate structure.
